### PR TITLE
Enable Robot Energy Multiplier to be modified via a setting

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -63,7 +63,7 @@ heat_pipe.heat_buffer.max_temperature = 2000
 
 data.raw["technology"]["nuclear-power"].unit.count = 400
 
-local robot_energy_multipler = 10
+local robot_energy_multipler = settings.startup["danger_ore_extra:robot_energy_multipler"].value
 
 local construction_robot = data.raw["construction-robot"]["construction-robot"]
 construction_robot.max_energy = (robot_energy_multipler * 1.5) .. "MJ"

--- a/locale/en/names.cfg
+++ b/locale/en/names.cfg
@@ -40,3 +40,6 @@ heat-exchanger-2=Heat exchanger 2
 [technology-name]
 electric-mining-drill=Electric mining drill
 steam-engine=Steam engine
+
+[mod-setting-name]
+danger_ore_extra:robot_energy_multipler=Robot Energy Multiplier

--- a/locale/ja/names.cfg
+++ b/locale/ja/names.cfg
@@ -1,0 +1,2 @@
+[mod-setting-name]
+danger_ore_extra:robot_energy_multipler=ロボットエネルギー乗数

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,11 @@
+data:extend{
+	{
+		name = 'danger_ore_extra:robot_energy_multipler',
+		type = 'int-setting',
+		setting_type = 'startup',
+		default_value = 10,
+		minimum_value = 1,
+		maximum_value = 100,
+		order = 'a'
+	}
+}


### PR DESCRIPTION
Allows the robot energy multiplier setting to be modified quickly via a setting.